### PR TITLE
Solve `traits` chapter

### DIFF
--- a/exercises/traits/traits1.rs
+++ b/exercises/traits/traits1.rs
@@ -9,14 +9,14 @@
 // implementing this trait.
 // Execute `rustlings hint traits1` or use the `hint` watch subcommand for a hint.
 
-// I AM NOT DONE
-
 trait AppendBar {
     fn append_bar(self) -> Self;
 }
 
 impl AppendBar for String {
-    // TODO: Implement `AppendBar` for type `String`.
+    fn append_bar(self) -> Self {
+        format!("{}Bar", self)
+    }
 }
 
 fn main() {

--- a/exercises/traits/traits2.rs
+++ b/exercises/traits/traits2.rs
@@ -11,13 +11,16 @@
 // you can do this!
 // Execute `rustlings hint traits2` or use the `hint` watch subcommand for a hint.
 
-// I AM NOT DONE
-
 trait AppendBar {
     fn append_bar(self) -> Self;
 }
 
-// TODO: Implement trait `AppendBar` for a vector of strings.
+impl AppendBar for Vec<String> {
+    fn append_bar(mut self) -> Self {
+        self.push(String::from("Bar"));
+        self
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/exercises/traits/traits3.rs
+++ b/exercises/traits/traits3.rs
@@ -7,10 +7,10 @@
 // Consider what you can add to the Licensed trait.
 // Execute `rustlings hint traits3` or use the `hint` watch subcommand for a hint.
 
-// I AM NOT DONE
-
 pub trait Licensed {
-    fn licensing_info(&self) -> String;
+    fn licensing_info(&self) -> String {
+        String::from("Some information")
+    }
 }
 
 struct SomeSoftware {

--- a/exercises/traits/traits4.rs
+++ b/exercises/traits/traits4.rs
@@ -4,8 +4,6 @@
 // Don't change any line other than the marked one.
 // Execute `rustlings hint traits4` or use the `hint` watch subcommand for a hint.
 
-// I AM NOT DONE
-
 pub trait Licensed {
     fn licensing_info(&self) -> String {
         "some information".to_string()
@@ -19,8 +17,8 @@ struct OtherSoftware {}
 impl Licensed for SomeSoftware {}
 impl Licensed for OtherSoftware {}
 
-// YOU MAY ONLY CHANGE THE NEXT LINE
-fn compare_license_types(software: ??, software_two: ??) -> bool {
+// trait を実装した型を受け入れる
+fn compare_license_types(software: impl Licensed, software_two: impl Licensed) -> bool {
     software.licensing_info() == software_two.licensing_info()
 }
 

--- a/exercises/traits/traits5.rs
+++ b/exercises/traits/traits5.rs
@@ -4,8 +4,6 @@
 // Don't change any line other than the marked one.
 // Execute `rustlings hint traits5` or use the `hint` watch subcommand for a hint.
 
-// I AM NOT DONE
-
 pub trait SomeTrait {
     fn some_function(&self) -> bool {
         true
@@ -26,8 +24,10 @@ impl OtherTrait for SomeStruct {}
 impl SomeTrait for OtherStruct {}
 impl OtherTrait for OtherStruct {}
 
+// Generic
+// fn some_func<T: SomeTrait + OtherTrait>(item: T) -> bool {
 // YOU MAY ONLY CHANGE THE NEXT LINE
-fn some_func(item: ??) -> bool {
+fn some_func(item: (impl SomeTrait + OtherTrait)) -> bool {
     item.some_function() && item.other_function()
 }
 


### PR DESCRIPTION
- 共通のメソッドをシグネチャで定義
- `for` で実装する struct を指定
- デフォルト実装
- impl キーワード
- 引数に複数の impl を受け入れる
