### PR TITLE
Solve `lifetimes` chapter

### DIFF
--- a/exercises/lifetimes/lifetimes1.rs
+++ b/exercises/lifetimes/lifetimes1.rs
@@ -7,9 +7,7 @@
 //
 // Execute `rustlings hint lifetimes1` or use the `hint` watch subcommand for a hint.
 
-// I AM NOT DONE
-
-fn longest(x: &str, y: &str) -> &str {
+fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
     if x.len() > y.len() {
         x
     } else {

--- a/exercises/lifetimes/lifetimes2.rs
+++ b/exercises/lifetimes/lifetimes2.rs
@@ -6,8 +6,6 @@
 //
 // Execute `rustlings hint lifetimes2` or use the `hint` watch subcommand for a hint.
 
-// I AM NOT DONE
-
 fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
     if x.len() > y.len() {
         x
@@ -22,6 +20,6 @@ fn main() {
     {
         let string2 = String::from("xyz");
         result = longest(string1.as_str(), string2.as_str());
+        println!("The longest string is '{}'", result);
     }
-    println!("The longest string is '{}'", result);
 }

--- a/exercises/lifetimes/lifetimes3.rs
+++ b/exercises/lifetimes/lifetimes3.rs
@@ -4,11 +4,9 @@
 //
 // Execute `rustlings hint lifetimes3` or use the `hint` watch subcommand for a hint.
 
-// I AM NOT DONE
-
-struct Book {
-    author: &str,
-    title: &str,
+struct Book<'a> {
+    author: &'a str,
+    title: &'a str,
 }
 
 fn main() {


### PR DESCRIPTION
- lifetime annotation
- result が strings2の参照を保持しているから同一スコープに合わせる
- 構造体のフィールドに参照をもたせる場合ライフタイム注釈を付ける必要がある
